### PR TITLE
Command Palette: Expand and collapse groups commands

### DIFF
--- a/command-palette/all-commands.js
+++ b/command-palette/all-commands.js
@@ -892,7 +892,6 @@ export const commands = [
         }
       });
     },
-    // condition: () => !!window.gZenFolders,
     icon: "chrome://browser/skin/zen-icons/folder.svg",
     tags: ["folder", "collapse", "group", "tabs", "all"],
   },
@@ -909,7 +908,6 @@ export const commands = [
         }
       });
     },
-    // condition: () => !!window.gZenFolders,
     icon: "chrome://browser/skin/zen-icons/folder.svg",
     tags: ["folder", "expand", "group", "tabs", "all"],
   },


### PR DESCRIPTION
These are two extra commands to expand and collapse all the groups from Advanced tab groups.