### PR TITLE
fix: update ollama-ai-provider to version 2 and adjust related imports

### DIFF
--- a/findbar-ai/llm/providers.js
+++ b/findbar-ai/llm/providers.js
@@ -4,7 +4,7 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { xai as createGrok } from "@ai-sdk/xai";
 import { createPerplexity } from "@ai-sdk/perplexity";
-import { createOllama } from "ollama-ai-provider";
+import { createOllama } from "ollama-ai-provider-v2";
 import PREFS from "../utils/prefs.js";
 
 // Base object with shared logic for all providers

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@ai-sdk/perplexity": "^2.0.13",
         "@ai-sdk/xai": "^2.0.26",
         "ai": "^5.0.72",
-        "ollama-ai-provider": "^1.2.0",
+        "ollama-ai-provider-v2": "^1.2.0",
         "zod": "^4.1.12"
       },
       "devDependencies": {
@@ -216,18 +216,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
       "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@ai-sdk/provider": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
-      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -1246,24 +1234,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
-    "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1274,43 +1244,32 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ollama-ai-provider": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ollama-ai-provider/-/ollama-ai-provider-1.2.0.tgz",
-      "integrity": "sha512-jTNFruwe3O/ruJeppI/quoOUxG7NA6blG3ZyQj3lei4+NnJo7bi3eIRWqlVpRlu/mbzbFXeJSBuYQWF6pzGKww==",
+    "node_modules/ollama-ai-provider-v2": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ollama-ai-provider-v2/-/ollama-ai-provider-v2-1.5.1.tgz",
+      "integrity": "sha512-5R3z7Y+mm8VEtoq+rIoIqkEy83oYM3DXX6Nyrn6yofYvYl56BCoJMNwXsPrpmCI0O4fN/gAIDTLpznYMRGzZ5g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "^1.0.0",
-        "@ai-sdk/provider-utils": "^2.0.0",
-        "partial-json": "0.1.7"
+        "@ai-sdk/provider": "^2.0.0",
+        "@ai-sdk/provider-utils": "^3.0.7"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
+        "zod": "^4.0.16"
       }
     },
-    "node_modules/ollama-ai-provider/node_modules/@ai-sdk/provider-utils": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
-      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+    "node_modules/ollama-ai-provider-v2/node_modules/@ai-sdk/provider": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
+      "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "nanoid": "^3.3.8",
-        "secure-json-parse": "^2.7.0"
+        "json-schema": "^0.4.0"
       },
       "engines": {
         "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.23.8"
       }
     },
     "node_modules/p-limit": {
@@ -1352,12 +1311,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/partial-json": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
-      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
-      "license": "MIT"
-    },
     "node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -1391,6 +1344,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1484,6 +1438,7 @@
       "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -1546,12 +1501,6 @@
       "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/secure-json-parse": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
-      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
@@ -1717,6 +1666,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@ai-sdk/perplexity": "^2.0.13",
     "@ai-sdk/xai": "^2.0.26",
     "ai": "^5.0.72",
-    "ollama-ai-provider": "^1.2.0",
+    "ollama-ai-provider-v2": "^1.2.0",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -47,7 +47,7 @@ const browseBotConfig = {
     manualChunks(id) {
       if (id.includes("node_modules")) {
         // Bundle Vercel AI SDK, Zod, and other AI libs into a vendor chunk
-        const vendorPackages = ["@ai-sdk", "ai", "zod", "ollama-ai-provider"];
+        const vendorPackages = ["@ai-sdk", "ai", "zod", "ollama-ai-provider-v2"];
         if (vendorPackages.some((pkg) => id.includes(pkg))) {
           return "vercel-ai-sdk";
         }


### PR DESCRIPTION
Vercel AI SDK 5 requires ollama-ai-provider-v2 otherwise attempting to use an ollama model will throw an error about api V1 being incompatible.
<img width="313" height="280" alt="image" src="https://github.com/user-attachments/assets/10ee5741-b2d2-4975-8454-f2507198a604" />
