### PR TITLE
compact-settings: fix about:addons sidebar for Zen 1.21.9 categories-box

### DIFF
--- a/compact-settings/addons.css
+++ b/compact-settings/addons.css
@@ -3,6 +3,9 @@
 
 @-moz-document url-prefix("about:addons") {
   @media -moz-pref("compact-settings.compact-addons.enabled") {
+    /* Since Zen 1.21.9 the sidebar is a categories-box rendering the same
+       moz-page-nav component as about:preferences, so the shell below mirrors
+       preferences.css exactly (same strip width, mask fade, hover flyout). */
     #full {
       display: block !important;
 
@@ -15,70 +18,41 @@
         box-sizing: border-box !important;
         width: var(--cs-strip-w) !important;
         overflow: hidden !important;
-        padding: 0 !important;
         margin: 0 !important;
+        padding: 0 !important;
+        padding-inline-start: 8px !important;
         background: var(--cs-sidebar-background) !important;
+        --font-size-xlarge: 0px;
+        mask-image: linear-gradient(to right, black 43px, transparent 47px) !important;
 
         @media -moz-pref("compact-settings.animation.enabled") {
           transition:
             width var(--cs-anim),
             box-shadow var(--cs-anim) !important;
-
-          .category {
-            transition: color var(--cs-anim) !important;
-          }
-
-          .sidebar-footer-label {
-            transition: opacity var(--cs-anim) !important;
-          }
         }
 
-        #categories,
-        sidebar-footer {
-          width: auto !important;
+        /* Zero the component's own 40px --page-nav-margin-inline-start and
+           inline padding so icon geometry matches the settings page (host
+           padding 8px + component internals); with the margin left in place
+           every icon lands past the 47px mask edge and the strip looks empty. */
+        moz-page-nav {
+          margin-inline-start: 0 !important;
+          padding-inline: 0 !important;
         }
 
-        .category {
-          margin-inline-start: 5px !important;
-          margin-inline-end: 0 !important;
-          width: 240px !important;
-          fill: var(--icon-color) !important;
-        }
+        moz-page-nav-button {
+          width: 225px !important;
 
-        &:not(:hover) {
-          .category {
-            color: transparent !important;
-          }
-          .sidebar-footer-label {
-            opacity: 0 !important;
-          }
-        }
-
-        .category[selected],
-        .category[aria-selected="true"] {
-          fill: var(--cs-accent) !important;
-        }
-
-        &:hover {
-          width: var(--cs-flyout-w) !important;
-          box-shadow: var(--cs-elevation) !important;
-
-          .category[selected],
-          .category[aria-selected="true"] {
+          &[selected] {
             color: var(--cs-accent) !important;
           }
         }
 
-        .sidebar-footer-list {
-          margin-inline-start: 8px !important;
-        }
-
-        .sidebar-footer-link {
-          width: 235px !important;
-        }
-
-        .sidebar-footer-label {
-          white-space: nowrap !important;
+        &:hover {
+          width: var(--cs-flyout-w) !important;
+          mask-image: none !important;
+          padding-inline-end: var(--space-small, 7.5px) !important;
+          box-shadow: var(--cs-elevation) !important;
         }
       }
 
@@ -87,31 +61,6 @@
         max-width: calc(100% - var(--cs-content-offset) - 8px) !important;
         height: 100vh !important;
         overflow-y: auto !important;
-      }
-    }
-
-    @media (max-width: 830px) {
-      .category-name {
-        display: block !important;
-      }
-
-      .category {
-        background-position-x: 10px !important;
-        background-position-y: 10px !important;
-      }
-
-      .sidebar-footer-list {
-        margin-inline: 6px !important;
-        display: block !important;
-      }
-
-      .sidebar-footer-icon {
-        margin-inline: 6px !important;
-        margin-left: 10px !important;
-      }
-
-      .sidebar-footer-label {
-        display: flex !important;
       }
     }
   }

--- a/compact-settings/release-notes.md
+++ b/compact-settings/release-notes.md
@@ -2,6 +2,8 @@
 
 # Fixes
 
+- Rewrote the about:addons sidebar rules for Zen 1.21.9+: the old `.category` / `sidebar-footer` markup was replaced by a `categories-box` component rendering the same `moz-page-nav` used on the settings page, so the compact sidebar showed nothing. The sidebar shell now mirrors preferences.css, and the component's 40px `--page-nav-margin-inline-start` is zeroed so icons stay inside the collapsed strip.
+
 # Others
 
 # Contributes

--- a/compact-settings/theme.json
+++ b/compact-settings/theme.json
@@ -8,8 +8,8 @@
   },
   "readme": "https://raw.githubusercontent.com/Vertex-Mods/Compact-Settings/main/README.md",
   "author": "Bibek Bhusal",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "tags": ["Settings", "Compact", "Addon", "Sidebar", "Grid"],
   "createdAt": "2024-01-26",
-  "updatedAt": "2026-07-20"
+  "updatedAt": "2026-07-30"
 }


### PR DESCRIPTION
Follow-up to #90.

Zen 1.21.9 (Firefox uplift) replaced the about:addons sidebar markup: the old `.category` buttons and `sidebar-footer` are gone, the sidebar is now a `categories-box` component that renders the same `moz-page-nav` used on about:preferences (light-DOM render root, footer links became `slot="secondary-nav"` nav buttons). Every sidebar selector in addons.css matched nothing and the compact strip rendered empty.

Changes in `addons.css`:

- Ported the preferences.css shell to `#full #sidebar`: 54px strip, mask fade, hover flyout, elevation shadow, `moz-page-nav-button` pinned at 225px, `--font-size-xlarge: 0px` for the heading. Both pages now share identical geometry and behavior.
- Zeroed the component's 40px `--page-nav-margin-inline-start` and inline padding. Without this every icon lands past the 47px mask edge and the collapsed strip looks blank.
- Removed the dead rules targeting the old markup (`.category`, `sidebar-footer`, narrow-window block).

Grid section selectors survived the update and are untouched. `theme.json` bumped to 1.1.2, release-notes.md updated.

Tested on Zen 1.21.9b (macOS, Sine): collapsed strip shows icons, hover flyout, selected accent, settings/help links all work; about:preferences unaffected.